### PR TITLE
AmCrアドカレ2019 12/2 公開日を設定

### DIFF
--- a/content/post/articles/advent_calendar/2019/02_0.md
+++ b/content/post/articles/advent_calendar/2019/02_0.md
@@ -1,7 +1,7 @@
 +++
 title =  "【Rust】serde_jsonの使い方"
-date = 2019-11-14T10:15:00+09:00
-draft = true
+date = 2019-12-02T00:00:00+09:00
+draft = false
 tags = ["アドベントカレンダー2019","Rust","serde_json"]
 featured_image = "/images/acac2019/2_00_hero.png"
 toc = true


### PR DESCRIPTION
`draft = true`にしなくても、`date`を将来の日付にしておけばコンバートされないらしい。

**ただし手動でNetlifyのビルドを走らせる必要がある**。