### PR TITLE
Impl/#45

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -5,5 +5,6 @@ draft = true
 tags = []
 toc = true
 featured_image = ""
+authors = []
 description = ""
 +++

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,11 @@ featured_image = "/images/hero.png"
 hasCJKLanguage = true
 enableEmoji = true
 
+[taxonomies]
+  author = "authors"
+  tag = "tags"
+  category = "categories"
+
 [blackfriday]
 hrefTargetBlank = true
 

--- a/layouts/partials/member.html
+++ b/layouts/partials/member.html
@@ -7,10 +7,10 @@
     {{ range .Tags }}
       <span class="f6">{{ . }}</span>
     {{ end }}
-    <h1 class="f3 near-black">
-      <span class="black">
+    <h1 class="f3 near-black title">
+      <a href="/authors/{{ urlize .Name }}" class="black">
         {{ .Name }}
-      </span>
+      </a>
     </h1>
     <div class="nested-links f5 lh-copy nested-copy-line-height">
       {{ .Description | markdownify }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -18,10 +18,19 @@
       <h1 class="f1 athelas mb1">
         {{ .Title | emojify }}
       </h1>
-      {{ with .Params.author }}
+      {{ with .Params.authors }}
       <p class="tracked">
-         By <strong>{{ . | markdownify }}</strong>
+          By 
+        {{ range . }}
+        <strong>{{ . | markdownify }}</strong>
+        {{ end }}
       </p>
+      {{ else }}
+        {{ with .Params.author }}
+        <p class="tracked">
+          By <strong>{{ . | markdownify }}</strong>
+        </p>
+        {{ end }}
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       <time class="f6 mv4 dib tracked" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -5,9 +5,9 @@
 
 {{ define "main" }}
   {{ $section := .Site.GetPage "section" .Section }}
-  <article class="flex-l flex-wrap justify-between mw8 center ph3">
+  <article class="flex-l flex-wrap justify-between mw8 center ph3" id="post">
 
-    <header class="mt4 w-100">
+    <header class="mt4 w-100" id="post-header">
       <p class="f6 b helvetica tracked">
           {{/*
           CurrentSection allows us to use the section title instead of inferring from the folder.
@@ -19,10 +19,10 @@
         {{ .Title | emojify }}
       </h1>
       {{ with .Params.authors }}
-      <p class="tracked">
+      <p class="tracked" id="post-header-authors">
           By 
         {{ range . }}
-        <strong>{{ . | markdownify }}</strong>
+        <strong class="author">{{ . | markdownify }}</strong>
         {{ end }}
       </p>
       {{ else }}
@@ -51,7 +51,7 @@
       </div>
     </header>
 
-    <section class="nested-copy-line-height lh-copy serif f4 nested-links nested-img mid-gray pr4-l w-two-thirds-l">
+    <section class="nested-copy-line-height lh-copy serif f4 nested-links nested-img mid-gray pr4-l w-two-thirds-l" id="post-content">
       {{- partial "tags.html" . -}}
       {{- .Content -}}
       <div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -22,7 +22,11 @@
       <p class="tracked" id="post-header-authors">
           By 
         {{ range . }}
-        <strong class="author">{{ . | markdownify }}</strong>
+        <strong class="author">
+          <a href='/authors/{{ urlize . }}'>
+            {{  . | markdownify }}
+          </a>
+        </strong>
         {{ end }}
       </p>
       {{ else }}

--- a/static/dist/css/members.css
+++ b/static/dist/css/members.css
@@ -20,11 +20,27 @@
     flex: 0 0 100%;
   }
 }
+
 .card > img.thumbnail {
   width: 100%;
   height: 20vh;
   object-fit: cover;
 }
+
+/*
+ * タイトルのa要素のスタイルをリセット (モダンブラウザのみ)
+ */
+.card > .document > .title > a {
+  all: unset;
+}
+.card > .document > .title > a:visited {
+  all: unset;
+}
+.card > .document > .title > a:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .card > .document > .socials {
   padding-top: 1em;
 }

--- a/static/dist/css/post.css
+++ b/static/dist/css/post.css
@@ -6,6 +6,23 @@
 }
 
 /*
+ * 著者名のスタイルをリセット (モダンブラウザのみ)
+ */
+#post-header > #post-header-authors .author > a {
+  all: unset;
+}
+#post-header > #post-header-authors .author > a:visited {
+  all: unset;
+}
+/*
+ * 著者名のスタイルを変更: マウスポインターを置いた時はリンクのように振る舞う
+ */
+#post-header > #post-header-authors .author > a:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/*
  * 本文中で同じ段落にあり, なおかつ隣接するimg要素どうしの間隔を開けている
  */
 #post-content > p > img + img {

--- a/static/dist/css/post.css
+++ b/static/dist/css/post.css
@@ -1,11 +1,14 @@
 /*
- * `main[role="main"] > article > section`: 記事の本文
+ * 記事に著者が複数いる場合, カンマ区切りで表示する
  */
+#post-header > #post-header-authors .author:not(:first-child)::before {
+  content: ', ';
+}
 
 /*
  * 本文中で同じ段落にあり, なおかつ隣接するimg要素どうしの間隔を開けている
  */
-main[role="main"] > article > section > p > img + img {
+#post-content > p > img + img {
   margin-top: 20px;
 }
 
@@ -13,12 +16,15 @@ main[role="main"] > article > section > p > img + img {
  * 本文中でテキストと隣接するimg要素にマージンを与えている
  * テキストが上下どちらに来てもいいように, img要素の上下にマージンを設定している
  */
-main[role="main"] > article > section > p > img:only-child {
+#post-content > p > img:only-child {
   margin-top: 20px;
   margin-bottom: 20px;
 }
 
-main[role="main"] > article > section > div.tags {
+/*
+ *　タグの表示領域の上下にマージンを与えている
+ */
+#post-content > div.tags {
   margin-top: 20px;
   margin-bottom: 20px;
 }

--- a/static/dist/css/post.css
+++ b/static/dist/css/post.css
@@ -6,7 +6,7 @@
 }
 
 /*
- * 著者名のスタイルをリセット (モダンブラウザのみ)
+ * 著者名のa要素のスタイルをリセット (モダンブラウザのみ)
  */
 #post-header > #post-header-authors .author > a {
   all: unset;


### PR DESCRIPTION
#45 を実装
- 記事のauthorsの表示を実装
   - 旧来の`author`パラメータにも対応 (`authors`の指定がない場合表示を試みる)
   - 記事の`authors`に著者ページへのリンクを設置
- membersのページのそれぞれのカードに著者ページへのリンクを設置
   - *書いた記事(精確には`authors`に自分が記名されている記事)*がない場合, 著者ページは生成されないことに注意
