### PR TITLE
Kaisei yokoyama patch for #59

### DIFF
--- a/content/post/articles/advent_calendar/2019/06_0.md
+++ b/content/post/articles/advent_calendar/2019/06_0.md
@@ -4,7 +4,7 @@ date = 2019-12-06T00:00:00+09:00
 draft = false
 tags = ["C++", "Lua"]
 toc = true
-author = "檸檬茶(Lemon TEA)"
+authors = ["檸檬茶(Lemon TEA)"]
 description = "Amusement Creators アドベントカレンダー 2019: 6日目 C++で作成したプログラムにLuaスクリプトを組み込む方法を示していきます."
 +++
 

--- a/content/post/articles/advent_calendar/2019/13_0.md
+++ b/content/post/articles/advent_calendar/2019/13_0.md
@@ -4,7 +4,7 @@ date = 2019-12-13T00:00:00+09:00
 draft = false
 tags = ["C++", "Lua"]
 toc = true
-author = "檸檬茶(Lemon TEA)"
+authors = ["檸檬茶(Lemon TEA)"]
 description = "Amusement Creators アドベントカレンダー 2019: 13日目 6日目で紹介した記事の内容を応用し,Luaスクリプトを実際にゲームに組み込む方法を紹介します."
 +++
 

--- a/content/post/articles/advent_calendar/2019/20_0.md
+++ b/content/post/articles/advent_calendar/2019/20_0.md
@@ -4,7 +4,7 @@ date = 2019-12-20T00:00:00+09:00
 draft = false
 tags = ["C#", "Roslyn"]
 toc = true
-author = "檸檬茶(Lemon TEA)"
+authors = ["檸檬茶(Lemon TEA)"]
 description = "Amusement Creators アドベントカレンダー 2019: 20日目 C#で作成したプログラムにC#スクリプトを組み込む方法を示していきます."
 +++
 


### PR DESCRIPTION
#45 での著者ページの実装の完了、およびそれに伴う#59 の変更のため、記事内容(精確にはプレフィックスの内容)を変更することを推奨します。

記事を公開する以上、この変更による著者への不利益はないものと思いますが、何かあれば(理由を言わずに)拒否して貰って構いません。任意です。`authors`ではなく、現状のまま`author`を使い続けても、著者ページへのリンクなどがないだけで著者名は記事に表示されます。

@GCLemon 確認お願いします