### PR TITLE
#77 仮対応が出来ていなかったのを修正

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ hrefTargetBlank = true
 
 [params]
   description = "筑波大学 Amusement Creators"
-  images = ["/images/hero.png"]
+  images = ["/images/share_thumnbail.png"]
   twitter = "https://twitter.com/ac_is_not_am"
 
 


### PR DESCRIPTION
- 間違えて、記事のデフォルトのヒーロー画像を指定していた
- 記事のデフォルトのヒーロー画像は変更したまま、さらにSNSのリンクの画像を設定し直した