### PR TITLE
#76 postセクションおよびその子孫セクションのインデックスページの表示を変更

### DIFF
--- a/layouts/post/list.html
+++ b/layouts/post/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+{{/*
+  This template is the same as the default and is here to demonstrate that if you have a content directory called "post" you can create a layouts directory, just for that section.
+   */}}
+  <article class="pa3 pa4-ns nested-copy-line-height nested-img">
+    <section class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy mid-gray">
+      {{ .Content }}
+    </section>
+    <aside class="flex-ns flex-wrap justify-around mt5">
+      {{ range (.Paginate (where .Site.Pages "Section" "post") 9).Pages }}
+      <div class="relative w-100 w-30-l mb4 bg-white">
+          {{/*
+          Note we can use `.Render` here for items just in this section, instead of a partial to pull in items for the list page. https://gohugo.io/functions/render/
+          */}}
+          {{ .Render "summary" }}
+        </div>
+      {{ end }}
+    </aside>
+    {{ template "_internal/pagination.html" . }}
+  </article>
+{{ end }}


### PR DESCRIPTION
自身が含む全ての記事(直下だけでなく子、孫セクションのも)を表示するように

![image](https://user-images.githubusercontent.com/8509057/69908601-84f73280-1430-11ea-8bfb-beb66c6a2dda.png)